### PR TITLE
fix: Make default templates refer to GUI pages (DSP-763)

### DIFF
--- a/src/ark-registry.ini
+++ b/src/ark-registry.ini
@@ -17,19 +17,19 @@ KnoraResourceIri: http://rdfh.ch/$project_id/$resource_id
 KnoraProjectIri: http://rdfh.ch/projects/$project_id
 
 # A template for generating redirect URLs referring to Knora projects.
-KnoraProjectRedirectUrl: http://$host/admin/projects/$project_iri
+KnoraProjectRedirectUrl: http://$host/project/$project_id/info
 
 # A template for generating redirect URLs referring to Knora resources.
-KnoraResourceRedirectUrl: http://$host/v2/resources/$resource_iri
+KnoraResourceRedirectUrl: http://$host/resource/$resource_iri
 
 # A template for generating redirect URLs referring to versions of Knora resources.
-KnoraResourceVersionRedirectUrl: http://$host/v2/resources/$resource_iri?version=$timestamp
+KnoraResourceVersionRedirectUrl: http://$host/resource/$resource_iri?version=$timestamp
 
 # A template for generating redirect URLs referring to Knora values.
-KnoraValueRedirectUrl: http://$host/v2/values/$resource_iri/$value_id
+KnoraValueRedirectUrl: http://$host/value/$resource_iri/$value_id
 
 # A template for generating redirect URLs referring to versions of Knora values.
-KnoraValueVersionRedirectUrl: http://$host/v2/values/$resource_iri/$value_id?version=$timestamp
+KnoraValueVersionRedirectUrl: http://$host/value/$resource_iri/$value_id?version=$timestamp
 
 # A template for generating redirect URLs referring to resources stored on the PHP-based server.
 PhpResourceRedirectUrl: http://$host/resources/$resource_int_id

--- a/src/ark.py
+++ b/src/ark.py
@@ -262,43 +262,43 @@ def test(settings):
     print("parse an ARK project URL: ", end='')
     ark_url_info = ArkUrlInfo(settings, "https://ark.example.org/ark:/00000/1/0001")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/admin/projects/http%3A%2F%2Frdfh.ch%2Fprojects%2F0001"
+    assert redirect_url == "http://0.0.0.0:3333/project/0001/info"
     print("OK")
 
     print("parse an ARK URL for a Knora resource without a timestamp: ", end='')
     ark_url_info = ArkUrlInfo(settings, "https://ark.example.org/ark:/00000/1/0001/cmfk1DMHRBiR4=_6HXpEFAn")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA"
+    assert redirect_url == "http://0.0.0.0:3333/resource/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA"
     print("OK")
 
     print("parse an ARK HTTP URL for a Knora resource without a timestamp: ", end='')
     ark_url_info = ArkUrlInfo(settings, "http://ark.example.org/ark:/00000/1/0001/cmfk1DMHRBiR4=_6HXpEFAn")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA"
+    assert redirect_url == "http://0.0.0.0:3333/resource/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA"
     print("OK")
 
     print("parse an ARK URL for a Knora resource with a timestamp with a fractional part: ", end='')
     ark_url_info = ArkUrlInfo(settings, "https://ark.example.org/ark:/00000/1/0001/cmfk1DMHRBiR4=_6HXpEFAn.20180604T085622513Z")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA?version=20180604T085622513Z"
+    assert redirect_url == "http://0.0.0.0:3333/resource/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA?version=20180604T085622513Z"
     print("OK")
 
     print("parse an ARK URL for a Knora resource with a timestamp without a fractional part: ", end='')
     ark_url_info = ArkUrlInfo(settings, "https://ark.example.org/ark:/00000/1/0001/cmfk1DMHRBiR4=_6HXpEFAn.20180604T085622Z")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/v2/resources/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA?version=20180604T085622Z"
+    assert redirect_url == "http://0.0.0.0:3333/resource/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA?version=20180604T085622Z"
     print("OK")
 
     print("parse an ARK URL for a Knora resource and value UUID without a timestamp: ", end='')
     ark_url_info = ArkUrlInfo(settings, "https://ark.example.org/ark:/00000/1/0001/cmfk1DMHRBiR4=_6HXpEFAn/pLlW4ODASumZfZFbJdpw1gu")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/v2/values/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g"
+    assert redirect_url == "http://0.0.0.0:3333/value/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g"
     print("OK")
 
     print("parse an ARK URL for a Knora resource and value UUID with a timestamp: ", end='')
     ark_url_info = ArkUrlInfo(settings, "https://ark.example.org/ark:/00000/1/0001/cmfk1DMHRBiR4=_6HXpEFAn/pLlW4ODASumZfZFbJdpw1gu.20180604T085622Z")
     redirect_url = ark_url_info.to_redirect_url()
-    assert redirect_url == "http://0.0.0.0:3333/v2/values/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g?version=20180604T085622Z"
+    assert redirect_url == "http://0.0.0.0:3333/value/http%3A%2F%2Frdfh.ch%2F0001%2Fcmfk1DMHRBiR4-_6HXpEFA/pLlW4ODASumZfZFbJdpw1g?version=20180604T085622Z"
     print("OK")
 
     print("parse a version 1 ARK URL for a PHP resource without a timestamp: ", end='')


### PR DESCRIPTION
This PR changes the default URL templates so they refer to DSP-UI routes instead of to Knora API routes. This should help with [DSP-763](https://dasch.myjetbrains.com/youtrack/issue/DSP-763).