### PR TITLE
fix: add PR title constraint in order to make release-please work

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -13,8 +13,5 @@ jobs:
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
-          regex: '^[a-z]+!?: .+$|^chore: release \d+\.\d+\.\d+$'
-          allowed_prefixes: "fix,refactor,feat,docs,chore,style,test" 
-          disallowed_prefixes: "feature,hotfix" 
-          prefix_case_sensitive: true 
+          regex: '^(feat|fix|docs|style|refactor|perf|test|chore)(\(.+\))?!?: .+$'
           max_length: 140

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,20 @@
+---
+
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  test:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          regex: '^[a-z]+!?: .+$|^chore: release \d+\.\d+\.\d+$'
+          allowed_prefixes: "fix,refactor,feat,docs,chore,style,test" 
+          disallowed_prefixes: "feature,hotfix" 
+          prefix_case_sensitive: true 
+          max_length: 140

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,7 @@ name: Release-Please
 on:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,4 +20,5 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           release-type: simple
           package-name: ark-resolver
+          pull-request-title-pattern: 'chore: release ${version}'
     


### PR DESCRIPTION
release-please works only when all commits follow the rules of conventional commit message (see here: https://github.com/google-github-actions/release-please-action/tree/v3/#how-should-i-write-my-commits).

So I have to add an additional check for this. This check should be made mandatory in the settings of this repo. Since I'm not admin, I can't do it. (see below: the check is executed and passes, but it is not marked "required").