### PR TITLE
fix: fix ark resolver not working

### DIFF
--- a/src/ark.py
+++ b/src/ark.py
@@ -45,6 +45,8 @@ from ark_url import (ArkUrlException, ArkUrlFormatter, ArkUrlInfo,
 #################################################################################################
 # Server implementation.
 
+Sanic.start_method = "fork"
+
 app = Sanic('ark_resolver')
 CORS(app)
 


### PR DESCRIPTION
ARK resolver seems to have been broken ever since the sanic was updated in https://github.com/dasch-swiss/ark-resolver/commit/8c2babfe1705b9263f5da6d4026d84f2a8246012

```
2024-05-07 14:03:30.810	| its-bs-meta-01 | ark-test-01_ark | KeyError: 'settings'                                     
2024-05-07 14:03:30.810	| its-bs-meta-01 | ark-test-01_ark |            ~~~~^^^^^^                                     
2024-05-07 14:03:30.810	| its-bs-meta-01 | ark-test-01_ark |     return self[attr]                                     
2024-05-07 14:03:30.810	| its-bs-meta-01 | ark-test-01_ark |   File "/usr/local/lib/python3.11/site-packages/sanic/config.py", line 163, in __getattr__                                     
2024-05-07 14:03:30.810	| its-bs-meta-01 | ark-test-01_ark | Traceback (most recent call last):                                     
2024-05-07 14:03:30.810	| its-bs-meta-01 | ark-test-01_ark | [2024-05-07 14:03:30 +0200] [15] [ERROR] Exception occurred while handling uri: 'http://ark.test.dasch.swiss/'                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark | AttributeError: Config has no 'settings'                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |     raise AttributeError(f"Config has no '{ke.args[0]}'")                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |   File "/usr/local/lib/python3.11/site-packages/sanic/config.py", line 165, in __getattr__                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |                                        ^^^^^^^^^^^^^^^^^^^                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |     redirect_url = ArkUrlInfo(settings=app.config.settings, ark_url=path, path_only=True).to_redirect_url()                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |   File "/app/ark.py", line 131, in catch_all                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |   File "handle_request", line 97, in handle_request                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark | Traceback (most recent call last):                                     
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark |                                      
2024-05-07 14:03:18.999	| its-bs-meta-01 | ark-test-01_ark | During handling of the above exception, another exception occurred:                                     
```

Seems like the `app.config.settings` value isn't propagated to the route handlers.

I've been able to track it down to this update https://sanic.readthedocs.io/en/stable/sanic/changelog.html#id53 / https://github.com/sanic-org/sanic/pull/2624.

The changelog mentions `Sanic.start_method = "fork"` for falling back to the old behaviour.

I don't know what it does or why it's needed, but it fixes the issue of ARK resolver not working at all. Perhaps a "proper" fix is in order, but we should get https://github.com/dasch-swiss/ark-resolver/pull/58 out asap.

