### PR TITLE
build(ci): remove PR title check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,11 +54,3 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy -- -D warnings
-  pr-title:
-    name: Check PR Title
-    runs-on: ubuntu-latest
-    steps:
-      - uses: deepakputhraya/action-pr-title@master
-        with:
-          regex: '^(build|chore|data|docs|feat|fix|perf|refactor|test|style)(\(.+\))?!?: .+$'
-          max_length: 140


### PR DESCRIPTION
PR title check is always failing with a strange error message. Don't want to spend time on fixing it.