### PR TITLE
refactor: extract catch_all route to dedicated redirect module

### DIFF
--- a/ark_resolver/ark.py
+++ b/ark_resolver/ark.py
@@ -36,6 +36,7 @@ from sentry_sdk.integrations.rust_tracing import RustTracingIntegration
 import ark_resolver.check_digit as check_digit_py
 import ark_resolver.routes.convert
 import ark_resolver.routes.health
+import ark_resolver.routes.redirect
 from ark_resolver import _rust  # type: ignore[attr-defined]
 from ark_resolver.ark_url import ArkUrlException
 from ark_resolver.ark_url import ArkUrlFormatter
@@ -51,9 +52,10 @@ Sanic.start_method = "fork"
 app = Sanic("ark_resolver")
 CORS(app)
 
-# Register health check route
+# Register routes
 app.blueprint(ark_resolver.routes.health.health_bp)
 app.blueprint(ark_resolver.routes.convert.convert_bp)
+app.blueprint(ark_resolver.routes.redirect.redirect_bp)
 
 
 @app.before_server_start
@@ -169,44 +171,6 @@ async def reload(req: Request) -> HTTPResponse:
             return response.text("Unauthorized", status=401)
 
 
-@app.get("/<path:path>")
-async def catch_all(_: Request, path: str = "") -> HTTPResponse:
-    """
-    Catch all URL. Tries to redirect the given ARK ID.
-    """
-    # Check if the path could be a valid ARK ID.
-    if not path.startswith("ark:/"):
-        msg = f"Invalid ARK ID: {path}"
-        return response.text(body=msg, status=400)
-
-    # Decode the ARK ID (idempotent operation).
-    ark_id_decoded = unquote(path)
-
-    with tracer.start_as_current_span("redirect") as span:
-        span.set_attribute("ark_id", ark_id_decoded)  # Attach ARK ID as metadata
-
-        try:
-            redirect_url = ArkUrlInfo(settings=app.config.settings, ark_id=ark_id_decoded).to_redirect_url()
-            span.set_status(Status(StatusCode.OK))  # Mark as successful
-
-        except ArkUrlException as ex:
-            span.set_status(Status(StatusCode.ERROR, "Invalid ARK ID"))
-            logger.error(f"Invalid ARK ID: {ark_id_decoded}")
-            return response.text(body=ex.message, status=400)
-
-        except check_digit_py.CheckDigitException as ex:
-            span.set_status(Status(StatusCode.ERROR, "Check Digit Error"))
-            logger.error(f"Invalid ARK ID (wrong check digit): {ark_id_decoded}", exc_info=ex)
-            return response.text(body=ex.message, status=400)
-
-        except KeyError as ex:
-            span.set_status(Status(StatusCode.ERROR, "KeyError (project not found)"))
-            logger.error(f"Invalid ARK ID (project not found): {ark_id_decoded}", exc_info=ex)
-            return response.text(body="Invalid ARK ID (project not found)", status=400)
-
-        span.add_event("Redirecting", {"redirect_url": redirect_url})
-        logger.info(f"Redirecting {ark_id_decoded} to {redirect_url}")
-        return response.redirect(redirect_url)
 
 
 def server(settings: ArkUrlSettings) -> None:

--- a/ark_resolver/routes/redirect.py
+++ b/ark_resolver/routes/redirect.py
@@ -1,0 +1,56 @@
+from urllib.parse import unquote
+
+from opentelemetry.trace import Status
+from opentelemetry.trace import StatusCode
+from sanic import Blueprint
+from sanic import HTTPResponse
+from sanic import Request
+from sanic import response
+from sanic.log import logger
+
+import ark_resolver.check_digit as check_digit_py
+from ark_resolver.ark_url import ArkUrlException
+from ark_resolver.ark_url import ArkUrlInfo
+from ark_resolver.tracing import tracer
+
+redirect_bp = Blueprint("redirect", url_prefix="")
+
+
+@redirect_bp.get("/<path:path>")
+async def catch_all(_: Request, path: str = "") -> HTTPResponse:
+    """
+    Catch all URL. Tries to redirect the given ARK ID.
+    """
+    # Check if the path could be a valid ARK ID.
+    if not path.startswith("ark:/"):
+        msg = f"Invalid ARK ID: {path}"
+        return response.text(body=msg, status=400)
+
+    # Decode the ARK ID (idempotent operation).
+    ark_id_decoded = unquote(path)
+
+    with tracer.start_as_current_span("redirect") as span:
+        span.set_attribute("ark_id", ark_id_decoded)  # Attach ARK ID as metadata
+
+        try:
+            redirect_url = ArkUrlInfo(settings=_.app.config.settings, ark_id=ark_id_decoded).to_redirect_url()
+            span.set_status(Status(StatusCode.OK))  # Mark as successful
+
+        except ArkUrlException as ex:
+            span.set_status(Status(StatusCode.ERROR, "Invalid ARK ID"))
+            logger.error(f"Invalid ARK ID: {ark_id_decoded}")
+            return response.text(body=ex.message, status=400)
+
+        except check_digit_py.CheckDigitException as ex:
+            span.set_status(Status(StatusCode.ERROR, "Check Digit Error"))
+            logger.error(f"Invalid ARK ID (wrong check digit): {ark_id_decoded}", exc_info=ex)
+            return response.text(body=ex.message, status=400)
+
+        except KeyError as ex:
+            span.set_status(Status(StatusCode.ERROR, "KeyError (project not found)"))
+            logger.error(f"Invalid ARK ID (project not found): {ark_id_decoded}", exc_info=ex)
+            return response.text(body="Invalid ARK ID (project not found)", status=400)
+
+        span.add_event("Redirecting", {"redirect_url": redirect_url})
+        logger.info(f"Redirecting {ark_id_decoded} to {redirect_url}")
+        return response.redirect(redirect_url)


### PR DESCRIPTION
- Move ARK redirect logic from main ark.py to routes/redirect.py
- Create redirect_bp blueprint for better code organization
- Maintain all existing functionality and error handling
- Improve code modularity and separation of concerns
- Preparation for parallel execution implementation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>