### PR TITLE
test: extend smoke test to cover convert and redirect routes

### DIFF
--- a/justfile
+++ b/justfile
@@ -72,7 +72,7 @@ test:
 
 # Run smoke tests that will spinn up a Docker container and call the health endpoint
 smoke-test: build
-    cargo test --tests smoke_test
+    cargo test --test smoke_test
 
 # Clean up build artifacts
 clean:

--- a/tests/smoke_test.rs
+++ b/tests/smoke_test.rs
@@ -1,9 +1,31 @@
 use assert_cmd::Command;
 use std::{thread, time::Duration};
 
+fn cleanup_docker() {
+    println!("Cleaning up Docker containers...");
+    let _ = Command::new("docker-compose")
+        .args(["down"])
+        .output();
+}
+
 #[test]
 fn smoke_test() {
+    // Step 0: Check if Docker is available
+    println!("Checking Docker availability...");
+    let docker_check = Command::new("docker")
+        .args(["--version"])
+        .output()
+        .expect("Failed to execute docker command");
+    
+    if !docker_check.status.success() {
+        panic!("Docker is not available. Please start Docker and try again.");
+    }
+
+    // Ensure cleanup happens even if test panics
+    std::panic::set_hook(Box::new(|_| cleanup_docker()));
+    
     // Step 1: Start the service using Docker
+    println!("Starting service with docker-compose...");
     let mut cmd = Command::new("docker-compose");
     cmd.args(["up", "-d"]).assert().success();
 
@@ -24,11 +46,51 @@ fn smoke_test() {
         }
     }
 
-    assert!(success, "Service did not become healthy in time!");
+    if !success {
+        cleanup_docker();
+        panic!("Service did not become healthy in time!");
+    }
 
-    // Step 3: Stop the service
-    Command::new("docker-compose")
-        .args(["down"])
-        .assert()
-        .success();
+    // Step 3: Test convert route (Version 0 ARK -> Version 1 ARK)
+    println!("Testing convert route...");
+    let convert_url = "http://localhost:3336/convert/ark:/99999/0002-751e0b8a-6";
+    match reqwest::blocking::get(convert_url) {
+        Ok(response) => {
+            if !response.status().is_success() {
+                cleanup_docker();
+                panic!("Convert route failed: {}", response.status());
+            }
+            println!("Convert route test passed");
+        }
+        Err(e) => {
+            cleanup_docker();
+            panic!("Convert route test failed: {}", e);
+        }
+    }
+
+    // Step 4: Test redirect route (Version 1 ARK -> redirect to resource)
+    println!("Testing redirect route...");
+    let redirect_url = "http://localhost:3336/ark:/99999/1/0002";
+    let client = reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("Failed to create HTTP client");
+    
+    match client.get(redirect_url).send() {
+        Ok(response) => {
+            if !response.status().is_redirection() {
+                cleanup_docker();
+                panic!("Redirect route should return 3xx status, got: {}", response.status());
+            }
+            println!("Redirect route test passed");
+        }
+        Err(e) => {
+            cleanup_docker();
+            panic!("Redirect route test failed: {}", e);
+        }
+    }
+
+    // Step 5: Stop the service
+    cleanup_docker();
+    println!("All tests passed!");
 }


### PR DESCRIPTION
- Add comprehensive testing for convert endpoint (Version 0 -> Version 1 ARK conversion)
- Add comprehensive testing for redirect endpoint (Version 1 ARK -> HTTP redirect)
- Implement robust Docker availability checks and cleanup handling
- Use correct ARK NAAN (99999) as configured in docker-compose.yml
- Fix justfile smoke-test command to use --test instead of --tests

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>