### PR TITLE
ci: deploy same image to stage on prod release, finalize Sentry release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,6 +123,7 @@ jobs:
     name: Finalize Sentry release
     runs-on: ubuntu-latest
     needs: [publish, trigger-prod-deployment]
+    if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
                -d "Service=ark&Version=${IMAGE_TAG}"
 
   trigger-prod-deployment:
-    name: Trigger deployment to PROD
+    name: Trigger deployment to PROD (and STAGE)
     runs-on: ubuntu-latest
     needs: publish
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
@@ -101,6 +101,41 @@ jobs:
           curl -f -u "${JENKINS_BASIC_AUTH_USER}:${JENKINS_BASIC_AUTH_PASS}" \
                -X POST "${JENKINS_UPDATE_RELEASE_WEBHOOK}" \
                -d "Service=ark&Version=${IMAGE_TAG}"
+      - name: Docker Scout — record staging (same image as PROD)
+        uses: docker/scout-action@v1
+        with:
+          command: environment
+          image: registry://daschswiss/ark-resolver:${{ needs.publish.outputs.tag }}
+          environment: staging
+          organization: daschswiss
+      - name: Trigger deployment to STAGE (same image as PROD)
+        env:
+          IMAGE_TAG: ${{ needs.publish.outputs.tag }}
+          JENKINS_BASIC_AUTH_USER: ${{ secrets.JENKINS_BASIC_AUTH_USER }}
+          JENKINS_BASIC_AUTH_PASS: ${{ secrets.JENKINS_BASIC_AUTH_PASS }}
+          JENKINS_UPDATE_RELEASE_WEBHOOK: ${{ secrets.JENKINS_UPDATE_STAGE_RELEASE_WEBHOOK }}
+        run: |
+          curl -f -u "${JENKINS_BASIC_AUTH_USER}:${JENKINS_BASIC_AUTH_PASS}" \
+               -X POST "${JENKINS_UPDATE_RELEASE_WEBHOOK}" \
+               -d "Service=ark&Version=${IMAGE_TAG}"
+
+  sentry-release:
+    name: Finalize Sentry release
+    runs-on: ubuntu-latest
+    needs: [publish, trigger-prod-deployment]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create and finalize Sentry release
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production
+          version: ${{ needs.publish.outputs.tag }}
 
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- When a GitHub release triggers prod deployment, the **same Docker image** is now also deployed to stage, ensuring both environments run identical images
- Docker Scout `staging` environment is updated alongside `production` to accurately reflect what's running where
- New `sentry-release` job finalizes the Sentry release after successful prod deployment using `getsentry/action-release@v3`

## Prerequisites (manual steps before merging)
- [x] Add `SENTRY_AUTH_TOKEN` secret (Sentry internal integration token with `release:admin` + `org:read` scopes)
- [x] Add `SENTRY_ORG` secret (Sentry organization slug)
- [x] Add `SENTRY_PROJECT` secret (Sentry project slug)
- [ ] Ensure deployment sets `ARK_SENTRY_RELEASE` to the Docker image tag at runtime

## Test plan
- [ ] Push to main → verify `trigger-stage-deployment` runs as before (no change to main push flow)
- [ ] Create a GitHub release → verify `trigger-prod-deployment` triggers both prod AND stage Jenkins webhooks
- [ ] Verify Docker Scout shows the release image tagged in both `production` and `staging` environments
- [ ] Verify `sentry-release` finalizes the release in Sentry with the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)