### PR TITLE
fix: repair malformed .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,9 +13,7 @@
       "Bash(just pycheck:*)",
       "Bash(cargo test:*)",
       "Bash(cargo check:*)",
-      "Bash(cargo clippy:*)",
-      "mcp__linear__get_project",
-      "mcp__linear__list_issues",
+      "Bash(cargo clippy:*)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## What

Fixes `.claude/settings.json`, which was invalid JSON and therefore silently ignored by Claude Code — meaning the project's permission allowlist was never applied.

Two changes:

1. **Remove the trailing comma** after `"mcp__linear__list_issues"` in the `allow` array. A comma after the final array element is invalid JSON. This was introduced in #121, where the entry was appended with a comma like the lines above it, while the previous (comma-less) last element got moved into the middle.
2. **Remove the two `mcp__linear__*` entries.** They referenced an MCP server named `linear` that is not defined anywhere in the repo (no `.mcp.json`), so they were no-ops for the team.

## Why it went unnoticed

- `just check` runs `rustcheck` + `pycheck`; neither validates JSON, so there was no lint gate on this file.
- Claude Code fails soft on a malformed settings file (silently ignores it) rather than erroring, so the broken permissions produced no visible failure.

## Testing

Validated with `python3 -c "import json; json.load(open('.claude/settings.json'))"` — parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4d9L2sLQADXgznTEm8UK7