### PR TITLE
fix(ci): gate the Claude workflow to org members (DEV-6884)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,15 +27,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Gate on author_association (DEV-6884): comment-triggered workflows always run from the
+  # default branch with secrets available, and "Require approval for all external
+  # contributors" covers only fork pull_request events — without this gate any GitHub
+  # account able to comment could spend the org's API key. workflow_dispatch stays ungated:
+  # dispatching already requires write access. A blocked trigger skips silently.
   claude:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '@claude')) ||
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '@claude'))
+        contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
[DEV-6884](https://linear.app/dasch/issue/DEV-6884)

## Summary
- Same org-wide gap as dasch-swiss/dsp-app#3337: this Claude workflow inherited the Anthropic quickstart without an author check, and comment-triggered workflows always run from the default branch with secrets available — so any GitHub account able to comment could fire the job and spend the org's `ANTHROPIC_API_KEY`.
- The triggering author must now be `OWNER`, `MEMBER` or `COLLABORATOR`; anything else (including `CONTRIBUTOR`, per the decision in DEV-6884) skips silently, exactly like a non-matching comment.

## Changes
- The allowlist check sits inside each trigger arm: `issue_comment` payloads also carry `issue.author_association` (the issue/PR author's), so a single OR-ed check would pass a stranger's comment on any issue or PR a member opened.
- `workflow_dispatch` stays ungated — dispatching already requires write access.

## Test Plan
- YAML parse validated locally; `contains(fromJSON('[...]'), ...author_association)` is the documented GitHub Actions idiom.
- Live verification (a member's trigger still fires) is only possible after merge — comment-event workflows run the workflow file from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)