### PR TITLE
fix(deps): drop sanic-cors and set the CORS header directly (PYSEC-2026-3539)

### DIFF
--- a/ark_resolver/ark.py
+++ b/ark_resolver/ark.py
@@ -29,7 +29,6 @@ from sanic import Request
 from sanic import Sanic
 from sanic import response
 from sanic.log import logger
-from sanic_cors import CORS  # type: ignore[import-untyped]
 
 import ark_resolver.check_digit as check_digit_py
 import ark_resolver.routes.convert
@@ -49,12 +48,28 @@ from ark_resolver.tracing import tracer
 Sanic.start_method = "fork"
 
 app = Sanic("ark_resolver")
-CORS(app)
 
 # Register routes
 app.blueprint(ark_resolver.routes.health.health_bp)
 app.blueprint(ark_resolver.routes.convert.convert_bp)
 app.blueprint(ark_resolver.routes.redirect.redirect_bp)
+
+
+@app.on_response
+async def add_cors_headers(_: Request, res: HTTPResponse) -> None:
+    """
+    Allow any origin to read resolver responses.
+
+    A static "*" rather than reflecting the request's Origin: every route is a public GET
+    and no credentials are involved, so there is no allowlist to scope. Reflecting an
+    origin is only ever needed together with credentials, which would itself be a defect
+    here -- and "*" makes that combination impossible rather than merely unused.
+
+    Replaces sanic-cors, which was removed: it contributed nothing beyond this header for
+    GET-only routes (simple cross-origin GETs are not preflighted), while carrying
+    PYSEC-2026-3539 with no published fix.
+    """
+    res.headers["Access-Control-Allow-Origin"] = "*"
 
 
 @app.before_server_start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,6 @@ license = "Apache-2.0"
 
 dependencies = [
   "sanic",
-  "Sanic-Cors",
-  "Sanic-Plugins-Framework",
   "sanic-routing",
   "aiofiles",
   "anyio",

--- a/tests/test_cors_headers.py
+++ b/tests/test_cors_headers.py
@@ -1,0 +1,37 @@
+# Copyright © 2015 - 2025 Swiss National Data and Service Center for the Humanities and/or DaSCH Service Platform contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the CORS response header the resolver sets on every response."""
+
+import asyncio
+
+from sanic import HTTPResponse
+
+from ark_resolver.ark import add_cors_headers
+
+
+def test_cors_header_allows_any_origin() -> None:
+    """Every response carries Access-Control-Allow-Origin, so browser clients can read it.
+
+    This replaced sanic-cors; without it, cross-origin JavaScript reads of resolver
+    responses would be blocked by the browser with no server-side error.
+    """
+    res = HTTPResponse()
+
+    asyncio.run(add_cors_headers(None, res))  # type: ignore[arg-type]
+
+    assert res.headers["Access-Control-Allow-Origin"] == "*"
+
+
+def test_cors_header_does_not_reflect_the_request_origin() -> None:
+    """The header is a constant, never the caller's Origin.
+
+    Reflecting an origin is only safe while no credentials are allowed; pinning "*" keeps
+    that combination unreachable rather than merely unused.
+    """
+    res = HTTPResponse()
+
+    asyncio.run(add_cors_headers(None, res))  # type: ignore[arg-type]
+
+    assert res.headers["Access-Control-Allow-Origin"] == "*"
+    assert "Access-Control-Allow-Credentials" not in res.headers

--- a/uv.lock
+++ b/uv.lock
@@ -51,8 +51,6 @@ dependencies = [
     { name = "requests" },
     { name = "rfc3986" },
     { name = "sanic" },
-    { name = "sanic-cors" },
-    { name = "sanic-plugins-framework" },
     { name = "sanic-routing" },
     { name = "sentry-sdk", extra = ["opentelemetry"] },
     { name = "sniffio" },
@@ -96,8 +94,6 @@ requires-dist = [
     { name = "requests" },
     { name = "rfc3986" },
     { name = "sanic" },
-    { name = "sanic-cors" },
-    { name = "sanic-plugins-framework" },
     { name = "sanic-routing" },
     { name = "sentry-sdk", extras = ["opentelemetry"] },
     { name = "sniffio" },
@@ -939,32 +935,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/e2/a902611ef48d0cf942093ad297d079f76ec46133a7dc8d1181aa1ab94bd2/sanic-25.12.1.tar.gz", hash = "sha256:7b51bf608e4030f06a6c002cd08fed2872e4936527e63c9a8a97d5cd06a2b47f", size = 375519, upload-time = "2026-05-31T19:45:46.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/91/5ecd9a91374a7b2831cf183357ceeb609fdfc8b390adb5cac90a261fe1f8/sanic-25.12.1-py3-none-any.whl", hash = "sha256:3874f1fe0442e3b12ce4a3f6524f676d5d3c43839c6a4967d1b82fd8db53c0f3", size = 258466, upload-time = "2026-05-31T19:45:45.27Z" },
-]
-
-[[package]]
-name = "sanic-cors"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "sanic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/b8/fd98a4842e54c1fb3d7b7bc85abbc6d76f79871763eb455a391ddfdb934d/Sanic-Cors-2.2.0.tar.gz", hash = "sha256:f8d7515da4c8b837871d422c66314c4b5704396a78894b59c50e26aa72a95873", size = 33670, upload-time = "2022-10-07T02:04:21.03Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/bb/749505a2b2580321d778e485bf6dd61fabeb0dc2294205a647242e832b74/Sanic_Cors-2.2.0-py2.py3-none-any.whl", hash = "sha256:c3b133ff1f0bb609a53db35f727f5c371dc4ebeb6be4cc2c37c19dd8b9301115", size = 18336, upload-time = "2022-10-07T02:04:18.424Z" },
-]
-
-[[package]]
-name = "sanic-plugins-framework"
-version = "0.9.4.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sanic" },
-    { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/b1/a870ed90dda230f314cc3ca5ad20e84ff055bc5ed2793dfd2655f5c6ddd3/Sanic-Plugins-Framework-0.9.4.post1.tar.gz", hash = "sha256:eea5b874c15255467c21acfb2e8b16b0e6bff5d11dffed698c63b2e759f3ec50", size = 23753, upload-time = "2020-10-20T02:33:16.149Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/f9/8b2dfad92df5fc37fb764c91b8a45754119ad6f3f9d289188d2bd6f6252f/Sanic_Plugins_Framework-0.9.4.post1-py2.py3-none-any.whl", hash = "sha256:958a648a891526022c33ef20f041782a211ad8bfe7efa21ec9626b9ac59ac6e8", size = 23391, upload-time = "2020-10-20T02:33:14.764Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `Python dependency audit` job fails on `sanic-cors 2.2.0` — [PYSEC-2026-3539](https://osv.dev/vulnerability/PYSEC-2026-3539): `try_match()` in `sanic_cors/core.py` uses `re.match` without end-anchoring, so a configured origin allowlist can be bypassed by registering a domain that begins with a trusted origin string (CVSS 6.5).

**There is no remedy by upgrading.** `2.2.0` is the latest release on PyPI and the advisory covers *"2.2.0 and prior"*. The only options were suppression or removal. This removes it.

## Why removal turned out to be the small change

I started from the assumption that dropping a CORS library from a live public service was risky and that suppressing the finding was the pragmatic call. Reading the library and the routes showed otherwise:

**`CORS(app)` was reflecting the caller's origin, not sending `*`.** With no arguments, `origins` resolves through `sanitize_regex_param('*')` → `re_fix('*')` → `['.*']`, and `DEFAULT_OPTIONS` has `send_wildcard=False`. So `get_cors_origins` skips the wildcard branch and falls to `try_match_any(request_origin, ['.*'])` → `re.match('.*', origin)` → always true → returns `[request_origin]`. The resolver echoed back whatever `Origin` it was given.

**The advisory was inert, but only by accident of configuration.** The flaw is an allowlist bypass; the only pattern here was `.*`, which matches everything by design, so there was no allowlist to defeat. That made suppression *defensible* — but it also meant the justification would silently expire the moment anyone tightened CORS.

**There was a live trap next to it.** sanic-cors guards the dangerous combination like this:

```python
if r'.*' in options['origins'] and options['supports_credentials'] and options['send_wildcard']:
    raise ValueError("Cannot use supports_credentials in conjunction with an origin string of '*'")
```

All three conditions are required. With `send_wildcard=False`, setting `supports_credentials=True` would have produced **origin reflection plus credentials allowed** — the classic critical CORS misconfiguration — and the library would **not** have raised.

**And the package was barely doing anything.** All three routes are GET (`health_bp.get`, `convert_bp.get`, `redirect_bp.get`), and simple cross-origin GETs are not preflighted, so the OPTIONS/preflight machinery — the substantial part of sanic-cors — never applied. CORS appeared in exactly three lines repo-wide: the `pyproject` entry, the import, and the call. No configuration, no tests, no documentation.

So the entire observable contribution was **one response header**.

## The change

```python
@app.on_response
async def add_cors_headers(_: Request, res: HTTPResponse) -> None:
    res.headers["Access-Control-Allow-Origin"] = "*"
```

A static `*` rather than a reflected origin. Reflection is only ever needed alongside credentials, which would itself be a defect on a public resolver — pinning `*` keeps that combination unreachable rather than merely unused, and browsers reject `*` with credentials by spec.

Also drops **`Sanic-Plugins-Framework`**, declared as a direct dependency but imported nowhere; it existed only for sanic-cors. `uv.lock` regenerated: **30 deletions, nothing else** — only the two packages, no version or format churn.

## Tests

The header had no coverage at all. Two tests added: that it is present, and that it is a constant rather than the caller's `Origin` (with no `Access-Control-Allow-Credentials`). Confirmed non-vacuous — changing the header value to a specific origin makes both fail:

```
E       AssertionError: assert 'https://example.org' == '*'
```

They test the handler directly rather than through an HTTP client, to avoid adding `sanic-testing` as a dependency in a PR whose purpose is removing dependencies.

## Verified locally with the commands CI runs

| Check | Result |
|---|---|
| `uv export … \| pip-audit` | **No known vulnerabilities found** |
| `just pycheck` (ruff format, ruff check, pyright) | clean — 23 files formatted, 0 errors |
| full `pytest` | **90 passed** |

## Behaviour change, stated plainly

Responses now carry `Access-Control-Allow-Origin: *` instead of the echoed request origin. For non-credentialed requests — which is all of them, since `supports_credentials` was never enabled — these are equivalent to clients. Any client that could have depended on reflection specifically would need credentials, which never worked here. Preflight behaviour is unchanged in practice because no route is preflighted.

Independent of the review-workflow rollout in #183; this branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
